### PR TITLE
Add setup scripts to `systemPackages` & VM testing environments to `packages`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,27 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build .#lasr_nightly_image -L
+
+  check-vm-images:
+    name: Build NixOS VM images
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix build .#lasr_nightly_vm -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build .#lasr_nightly_vm -L
+      - run: nix build .#lasr_vm -L

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+*.qcow2

--- a/README.md
+++ b/README.md
@@ -7,11 +7,19 @@ and [NixOS images & infrastructure for deploying Versatus services](./deployment
 ## Prerequisites
 
 Nix is a package manager with a focus on reproducibility and reliability.
-To get started, choose an installation type at https://nixos.org/download.
+To get started, choose an installation type at https://nixos.org/download. MacOS users, please read on.
+
+**For MacOS users**, the graphical installer made available by Determinate Systems has some advantages and is recommended over the official installer, which are explained and can be found here: https://determinate.systems/posts/graphical-nix-installer.
+
+Additionally, MacOS users may want to enable the `nix-darwin` module features in order to run linux virtual machines locally, otherwise this step may be skipped.
+There are two resources we recommend for getting started with `nix-darwin` which should be followed in this order:
+1. [nix-darwin setup](https://nixcademy.com/2024/01/15/nix-on-macos/#step-2-going-declarative-with-nix-darwin) 
+2. [nix-darwin linux builder](https://nixcademy.com/2024/02/12/macos-linux-builder/#the-nix-darwin-option)
 
 ### Nixpkgs
 
 For the Nix package manager on non-NixOS distributions, add the following to `/etc/nix/nix.conf`:
+> Note: If you used the Determinate Systems Nix installer, these settings are enabled by default.
 ```
 experimental-features = nix-command flakes
 ```
@@ -23,7 +31,7 @@ For the Nix operating system, add the following to `/etc/nixos/configuration.nix
 nix.settings.experimental-features = [ "nix-command" "flakes" ];
 ```
 
-## Quick Start
+## Developer Quick Start
 
 First, ensure your system is listed under [Supported Systems](#supported-systems).
 
@@ -38,6 +46,7 @@ nix develop .#<development-shell>
 - x86_64-darwin
 - aarch64-linux
 - aarch64-darwin
+> Note: The Determinate Systems Nix installer also supports WSL.
 
 ### Development Shells
 

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -1,5 +1,13 @@
 { pkgs, ... }:
 let
+  # Pull the PD server image from dockerhub
+  pd-image = pkgs.dockerTools.pullImage {
+    imageName = "pingcap/pd";
+    imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
+    sha256 = "sha256-vYz5zpWuFlOao8NCrfexfmF5+5kp4j0FDslRC1VSExU=";
+    finalImageTag = "latest";
+    finalImageName = "pd";
+  };
   # Starts the placement driver server for TiKV.
   start-pd-server = pkgs.writeShellScriptBin "start-pd-server.sh" ''
     docker run -d --name pd-server --network host pingcap/pd:latest \
@@ -10,6 +18,14 @@ let
         --advertise-client-urls="http://0.0.0.0:2379" \
         --advertise-peer-urls="http://0.0.0.0:2380"
   '';
+  # Pull the TiKV server image from dockerhub
+  tikv-image = pkgs.dockerTools.pullImage {
+    imageName = "pingcap/tikv";
+    imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
+    sha256 = "sha256-ZM+6nZKBnN9aUZ8g9aw+20hV3i1RpMSjEVNLz1OOf0E=";
+    finalImageTag = "latest";
+    finalImageName = "tikv";
+  };
   # Starts the TiKV server.
   start-tikv-server = pkgs.writeShellScriptBin "start-tikv-server.sh" ''
     docker run -d --name tikv-server --network host pingcap/tikv:latest \
@@ -120,6 +136,7 @@ in
     containers = {
       pd-server = {
         image = "pingcap/pd:latest";
+        imageFile = pd-image;
         extraOptions = [
           "--network=host"
         ];
@@ -134,6 +151,7 @@ in
       tikv-server = {
         dependsOn = [ "pd-server" ];
         image = "pingcap/tikv:latest";
+        imageFile = tikv-image;
         extraOptions = [
           "--network=host"
         ];

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -1,10 +1,13 @@
 { pkgs, ... }:
 let
   # Pull the PD server image from dockerhub
-  pd-image = pkgs.dockerTools.pullImage {
+  pd-image = let
+    digest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
+  in
+  pkgs.dockerTools.pullImage {
     imageName = "pingcap/pd";
-    imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
-    sha256 = "sha256-+IBB5p1M8g3fLjHbF90vSSAoKUidl5cdkpTulkzlMAc=";
+    imageDigest = digest;
+    sha256 = builtins.hashString "sha256" digest;
     finalImageTag = "latest";
     finalImageName = "pingcap/pd";
   };
@@ -19,10 +22,13 @@ let
         --advertise-peer-urls="http://0.0.0.0:2380"
   '';
   # Pull the TiKV server image from dockerhub
-  tikv-image = pkgs.dockerTools.pullImage {
+  tikv-image = let
+    digest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
+  in
+  pkgs.dockerTools.pullImage {
     imageName = "pingcap/tikv";
-    imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
-    sha256 = "sha256-JbogHq9FLfm7x08xkwiDF0+YyUKRXF34vHty+ZxIZh0=";
+    imageDigest = digest;
+    sha256 = builtins.hashString "sha256" digest;
     finalImageTag = "latest";
     finalImageName = "pingcap/tikv";
   };

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -1,13 +1,18 @@
 { pkgs, ... }:
 let
+  system = builtins.replaceStrings [ "darwin" ] [ "linux" ] pkgs.stdenv.hostPlatform.system;
   # Pull the PD server image from dockerhub
   pd-image = let
-    digest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
+    # TODO: Figure out how to automatically generate this.
+    sha =
+      if system == "aarch64-linux" then "sha256-+IBB5p1M8g3fLjHbF90vSSAoKUidl5cdkpTulkzlMAc="
+      else if system == "x86_64-linux" then "sha256-xNPJrv8y6vjAPNvn9lAkghCfRGUDiBfRCUBsEYvb49Q="
+      else builtins.throw "Unsupported platform, must either be arm64 or amd64 Linux";
   in
   pkgs.dockerTools.pullImage {
     imageName = "pingcap/pd";
-    imageDigest = digest;
-    sha256 = builtins.hashString "sha256" digest;
+    imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
+    sha256 = sha;
     finalImageTag = "latest";
     finalImageName = "pingcap/pd";
   };
@@ -23,12 +28,16 @@ let
   '';
   # Pull the TiKV server image from dockerhub
   tikv-image = let
-    digest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
+    # TODO: Figure out how to automatically generate this.
+    sha =
+      if system == "aarch64-linux" then "sha256-JbogHq9FLfm7x08xkwiDF0+YyUKRXF34vHty+ZxIZh0="
+      else if system == "x86_64-linux" then "sha256-udLF3mAuUU08QX2Tg/mma9uu0JdtdJuxK3R1bqdKjKk="
+      else builtins.throw "Unsupported platform, must either be arm64 or amd64 Linux";
   in
   pkgs.dockerTools.pullImage {
     imageName = "pingcap/tikv";
-    imageDigest = digest;
-    sha256 = builtins.hashString "sha256" digest;
+    imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
+    sha256 = sha;
     finalImageTag = "latest";
     finalImageName = "pingcap/tikv";
   };

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -43,6 +43,10 @@ let
     cd /app
     printf "${procfile.text}" > "${procfile.name}"
     git clone https://github.com/versatus/lasr.git
+    # TODO: handle secret key between boots, possibly by adding
+    # it to `bashrc`.
+    export SECRET_KEY=$(lasr_cli wallet new | jq '.secret_key')
+
     cd /app/bin
     printf "${start-ipfs.text}" > "${start-ipfs.name}"
     printf "${start-lasr.text}" > "${start-lasr.name}"
@@ -69,6 +73,7 @@ let
     destination = "/app/bin/start-ipfs.sh";
   };
 
+  # TODO: Move these env vars from this script, they should go wherever $SECRET_KEY goes.
   # Starts the lasr_node from the release build.
   start-lasr = pkgs.writeTextFile {
     name = "start-lasr.sh";
@@ -76,7 +81,6 @@ let
       PREFIX=/app/lasr
       cd $PREFIX
 
-      SECRET_KEY=d2a31d0cc7152019b30a8764733e19f14e4fb5f83a530cb011eaeaf1b4f5c882 \
       BLOCKS_PROCESSED_PATH="/app/blocks_processed.dat" \
       ETH_RPC_URL="https://u0anlnjcq5:xPYLI9OMwxRqJZqhfgEiKMeGdpVjGduGKmMCNBsu46Y@u0auvfalma-u0j1mdxq0w-rpc.us0-aws.kaleido.io/" \
       EO_CONTRACT_ADDRESS=0x563f0efeea703237b32ae7f66123b864f3e46a3c \
@@ -118,6 +122,7 @@ in
     git
     grpcurl
     gvisor
+    jq
     kubo
     overmind
     tmux

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -4,9 +4,9 @@ let
   pd-image = pkgs.dockerTools.pullImage {
     imageName = "pingcap/pd";
     imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
-    sha256 = "sha256-vYz5zpWuFlOao8NCrfexfmF5+5kp4j0FDslRC1VSExU=";
+    sha256 = "sha256-xNPJrv8y6vjAPNvn9lAkghCfRGUDiBfRCUBsEYvb49Q=";
     finalImageTag = "latest";
-    finalImageName = "pd";
+    finalImageName = "pingcap/pd";
   };
   # Starts the placement driver server for TiKV.
   start-pd-server = pkgs.writeShellScriptBin "start-pd-server.sh" ''
@@ -22,9 +22,9 @@ let
   tikv-image = pkgs.dockerTools.pullImage {
     imageName = "pingcap/tikv";
     imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
-    sha256 = "sha256-ZM+6nZKBnN9aUZ8g9aw+20hV3i1RpMSjEVNLz1OOf0E=";
+    sha256 = "sha256-udLF3mAuUU08QX2Tg/mma9uu0JdtdJuxK3R1bqdKjKk=";
     finalImageTag = "latest";
-    finalImageName = "tikv";
+    finalImageName = "pingcap/tikv";
   };
   # Starts the TiKV server.
   start-tikv-server = pkgs.writeShellScriptBin "start-tikv-server.sh" ''

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -1,14 +1,5 @@
 { pkgs, ... }:
 let
-  # TODO: Pull dockerhub images declaratively.
-  # Pull the PD server image from dockerhub.
-  # pd-image-tar = pkgs.dockerTools.pullImage {
-  #   imageName = "pingcap/pd";
-  #   imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
-  #   sha256 = "sha256-vYz5zpWuFlOao8NCrfexfmF5+5kp4j0FDslRC1VSExU=";
-  #   finalImageTag = "latest";
-  #   finalImageName = "pd";
-  # };
   # Starts the placement driver server for TiKV.
   start-pd-server = pkgs.writeShellScriptBin "start-pd-server.sh" ''
     docker run -d --name pd-server --network host pingcap/pd:latest \
@@ -19,15 +10,6 @@ let
         --advertise-client-urls="http://0.0.0.0:2379" \
         --advertise-peer-urls="http://0.0.0.0:2380"
   '';
-
-  # Pull the TiKV server image from dockerhub.
-  # tikv-image-tar = pkgs.dockerTools.pullImage {
-  #   imageName = "pingcap/tikv";
-  #   imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
-  #   sha256 = "sha256-ZM+6nZKBnN9aUZ8g9aw+20hV3i1RpMSjEVNLz1OOf0E=";
-  #   finalImageTag = "latest";
-  #   finalImageName = "tikv";
-  # };
   # Starts the TiKV server.
   start-tikv-server = pkgs.writeShellScriptBin "start-tikv-server.sh" ''
     docker run -d --name tikv-server --network host pingcap/tikv:latest \
@@ -112,6 +94,38 @@ in
   # Enable docker socket
   virtualisation.docker.enable = true;
   users.users.root.extraGroups = [ "docker" ];
+  # Automatically start the pd-server & tikv-server on server start
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers = {
+      pd-server = {
+        image = "pingcap/pd:latest";
+        extraOptions = [
+          "--network=host"
+        ];
+        cmd = [ 
+          "--data-dir=/pd1"
+          "--client-urls=http://0.0.0.0:2379" 
+          "--peer-urls=http://0.0.0.0:2380" 
+          "--advertise-client-urls=http://0.0.0.0:2379"
+          "--advertise-peer-urls=http://0.0.0.0:2380"
+        ];
+      };
+      tikv-server = {
+        dependsOn = [ "pd-server" ];
+        image = "pingcap/tikv:latest";
+        extraOptions = [
+          "--network=host"
+        ];
+        cmd = [
+          "--addr=127.0.0.1:20160"
+          "--advertise-addr=127.0.0.1:20160"
+          "--data-dir=/tikv"
+          "--pd=http://127.0.0.1:2379"
+        ];
+      };
+    };
+  };
 
   # Before changing, read this first:
   # https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 let
-  system = builtins.replaceStrings [ "darwin" ] [ "linux" ] pkgs.stdenv.hostPlatform.system;
+  system = pkgs.stdenv.hostPlatform.system;
   # Pull the PD server image from dockerhub
   pd-image = let
     # TODO: Figure out how to automatically generate this.

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 let
   # TODO: Pull dockerhub images declaratively.
-  # Pull the PD server image from dockerhub
+  # Pull the PD server image from dockerhub.
   # pd-image-tar = pkgs.dockerTools.pullImage {
   #   imageName = "pingcap/pd";
   #   imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
@@ -9,8 +9,8 @@ let
   #   finalImageTag = "latest";
   #   finalImageName = "pd";
   # };
-  # Starts the placement driver server for TiKV
-  pd-server = pkgs.writeShellScriptBin "pd-server.sh" ''
+  # Starts the placement driver server for TiKV.
+  start-pd-server = pkgs.writeShellScriptBin "start-pd-server.sh" ''
     docker run -d --name pd-server --network host pingcap/pd:latest \
         --name="pd1" \
         --data-dir="/pd1" \
@@ -20,7 +20,7 @@ let
         --advertise-peer-urls="http://0.0.0.0:2380"
   '';
 
-  # Pull the TiKV server image from dockerhub
+  # Pull the TiKV server image from dockerhub.
   # tikv-image-tar = pkgs.dockerTools.pullImage {
   #   imageName = "pingcap/tikv";
   #   imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
@@ -28,14 +28,65 @@ let
   #   finalImageTag = "latest";
   #   finalImageName = "tikv";
   # };
-  # Starts the TiKV server
-  tikv-server = pkgs.writeShellScriptBin "tikv-server.sh" ''
+  # Starts the TiKV server.
+  start-tikv-server = pkgs.writeShellScriptBin "start-tikv-server.sh" ''
     docker run -d --name tikv-server --network host pingcap/tikv:latest \
         --addr="127.0.0.1:20160" \
         --advertise-addr="127.0.0.1:20160" \
         --data-dir="/tikv" \
         --pd="http://127.0.0.1:2379"
   '';
+
+  # Starts kubo IPFS daemon.
+  start-ipfs = pkgs.writeTextFile {
+    name = "start-ipfs.sh";
+    text = ''
+      IPFS_PATH=/app/tmp/kubo ipfs daemon
+    '';
+    executable = true;
+    destination = "/app/bin/start-ipfs.sh";
+  };
+
+  # Starts the lasr_node from the release build.
+  start-lasr = pkgs.writeTextFile {
+    name = "start-lasr.sh";
+    text = ''
+      PREFIX=/app/lasr
+      cd $PREFIX
+
+      # TODO: Figure out a way to pass the secret key securely.
+      # SECRET_KEY= \
+      BLOCKS_PROCESSED_PATH="/app/blocks_processed.dat" \
+      ETH_RPC_URL="https://u0anlnjcq5:xPYLI9OMwxRqJZqhfgEiKMeGdpVjGduGKmMCNBsu46Y@u0auvfalma-u0j1mdxq0w-rpc.us0-aws.kaleido.io/" \
+      EO_CONTRACT_ADDRESS=0x563f0efeea703237b32ae7f66123b864f3e46a3c \
+      COMPUTE_RPC_URL=ws://localhost:9125 \
+      STORAGE_RPC_URL=ws://localhost:9126 \
+      BATCH_INTERVAL=180 \
+      	/app/lasr/target/release/lasr_node
+    '';
+    executable = true;
+    destination = "/app/bin/start-lasr.sh";
+  };
+
+  # Main process script. Re/starts the node and dependencies.
+  start-overmind = pkgs.writeTextFile {
+    name = "start-overmind.sh"; 
+    text = ''
+      OVERMIND_CAN_DIE=reset overmind start -D -N /app/Procfile
+    '';
+    executable = true;
+    destination = "/app/bin/start-overmind.sh";
+  };
+  # Overmind's configuration file.
+  # The destination path is automatically created.
+  procfile = pkgs.writeTextFile {
+    name = "Procfile";
+    text = ''
+      ipfs: /app/bin/start-ipfs.sh
+      lasr: sleep 5 && /app/bin/start-lasr.sh
+    '';
+    destination = "/app/Procfile";
+  };
 in
 {
   # Packages that will be available on the resulting NixOS system.
@@ -50,8 +101,12 @@ in
     overmind
     tmux
   ] ++ [
-    pd-server
-    tikv-server
+    start-pd-server
+    start-tikv-server
+    start-ipfs
+    start-lasr
+    start-overmind
+    procfile
   ];
 
   # Enable docker socket

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -4,7 +4,7 @@ let
   pd-image = pkgs.dockerTools.pullImage {
     imageName = "pingcap/pd";
     imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
-    sha256 = "sha256-xNPJrv8y6vjAPNvn9lAkghCfRGUDiBfRCUBsEYvb49Q=";
+    sha256 = "sha256-+IBB5p1M8g3fLjHbF90vSSAoKUidl5cdkpTulkzlMAc=";
     finalImageTag = "latest";
     finalImageName = "pingcap/pd";
   };
@@ -22,7 +22,7 @@ let
   tikv-image = pkgs.dockerTools.pullImage {
     imageName = "pingcap/tikv";
     imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
-    sha256 = "sha256-udLF3mAuUU08QX2Tg/mma9uu0JdtdJuxK3R1bqdKjKk=";
+    sha256 = "sha256-JbogHq9FLfm7x08xkwiDF0+YyUKRXF34vHty+ZxIZh0=";
     finalImageTag = "latest";
     finalImageName = "pingcap/tikv";
   };

--- a/deployments/lasr_node/common.nix
+++ b/deployments/lasr_node/common.nix
@@ -123,10 +123,10 @@ in
         extraOptions = [
           "--network=host"
         ];
-        cmd = [ 
+        cmd = [
           "--data-dir=/pd1"
-          "--client-urls=http://0.0.0.0:2379" 
-          "--peer-urls=http://0.0.0.0:2380" 
+          "--client-urls=http://0.0.0.0:2379"
+          "--peer-urls=http://0.0.0.0:2380"
           "--advertise-client-urls=http://0.0.0.0:2379"
           "--advertise-peer-urls=http://0.0.0.0:2380"
         ];

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716156051,
-        "narHash": "sha256-TjUX7WWRcrhuUxDHsR8pDR2N7jitqZehgCVSy3kBeS8=",
+        "lastModified": 1718730147,
+        "narHash": "sha256-QmD6B6FYpuoCqu6ZuPJH896ItNquDkn0ulQlOn4ykN8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7443df1c478947bf96a2e699209f53b2db26209d",
+        "rev": "32c21c29b034d0a93fdb2379d6fabc40fc3d0e6c",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1716359173,
-        "narHash": "sha256-pYcjP6Gy7i6jPWrjiWAVV0BCQp+DdmGaI/k65lBb/kM=",
+        "lastModified": 1717827974,
+        "narHash": "sha256-ixopuTeTouxqTxfMuzs6IaRttbT8JqRW5C9Q/57WxQw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "b6fc5035b28e36a98370d0eac44f4ef3fd323df6",
+        "rev": "ab655c627777ab5f9964652fe23bbb1dfbd687a8",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     "lasr": {
       "flake": false,
       "locked": {
-        "lastModified": 1715976987,
-        "narHash": "sha256-2J8ccxKYLlYesEWPoKoUR78bJKH7h2Z7iBVPPdGWaRA=",
+        "lastModified": 1718669913,
+        "narHash": "sha256-bAfhF4/HR4SVzDQhqibRYMS/wTijKpCoAZ5hAo2JJ6I=",
         "owner": "versatus",
         "repo": "lasr",
-        "rev": "46cf0e5b1b7c62a28468d2e73b8583c070917971",
+        "rev": "1ccb177ec0bf879353756f5437b1bccab46a6563",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716358718,
-        "narHash": "sha256-NQbegJb2ZZnAqp2EJhWwTf6DrZXSpA6xZCEq+RGV1r0=",
+        "lastModified": 1718606988,
+        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3f316d2a50699a78afe5e77ca486ad553169061e",
+        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     "versatus": {
       "flake": false,
       "locked": {
-        "lastModified": 1710439957,
-        "narHash": "sha256-cMbBxs+2mxRs2MN0/gXc1Nn9axNMdwqmc4gua4oJsLk=",
+        "lastModified": 1717000637,
+        "narHash": "sha256-oCKOYZPSGT+Hbp/IoyzeEzPwBkogkYIJA+Eu8IXhGMY=",
         "owner": "versatus",
         "repo": "versatus",
-        "rev": "ef8475acbc905d4a48679330f4bb346c12fe07e5",
+        "rev": "217a0e73fa9284286e1482d50c2af260ada4f51c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -398,7 +398,10 @@
             virtualisation.forwardPorts = [
               { from = "host"; host.port = 2222; guest.port = 22; }
             ];
-            virtualisation.diskSize = 2048;
+            virtualisation = {
+              diskSize = 2048;
+              memorySize = 4096;
+            };
 
             users.users.root.hashedPassword = "";
 

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,13 @@
         cargoArtifacts = lasrDeps;
         cargoExtraArgs = "--locked --bin lasr_node";
       });
+      lasrCliDrv = craneLib.buildPackage (lasrArgs // {
+        pname = "lasr_cli";
+        version = "1";
+        doCheck = false;
+        cargoArtifacts = lasrDeps;
+        cargoExtraArgs = "--locked --bin lasr_cli";
+      });
     in
     {
       # TODO: enable checks
@@ -205,6 +212,8 @@
 
         lasr_node = lasrNodeDrv;
 
+        lasr_cli = lasrCliDrv;
+
         lasr_nightly_image =
           self.nixosConfigurations.lasr_nightly.config.system.build.digitalOceanImage;
 
@@ -213,7 +222,7 @@
         lasr_nightly_vm =
           self.nixosConfigurations.lasr_nightly_vm.config.system.build.vm;
 
-        # lasr_cli = # this works on Linux only at the moment
+        # lasr_cli_cross = # this works on Linux only at the moment
         #   let
         #     archPrefix = builtins.elemAt (pkgs.lib.strings.split "-" system) 0;
         #     target = "${archPrefix}-unknown-linux-musl";
@@ -364,6 +373,7 @@
             # Variant 1: Inject via Flake
             environment.systemPackages = [
               self.packages.${system}.lasr_node
+              self.packages.${system}.lasr_cli
             ];
 
             # Variant 2: Inject via overlay
@@ -400,7 +410,10 @@
             # Variant 1: Inject via Flake
             environment.systemPackages = [
               self.packages.${system}.lasr_node
+              self.packages.${system}.lasr_cli
             ];
+
+            nix.settings.experimental-features = ["nix-command" "flakes"];
           })
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -392,10 +392,13 @@
           ./deployments/lasr_node/nightly/nightly-options.nix
           ({ modulesPath, ... }: {
             imports = [ (modulesPath + "/virtualisation/qemu-vm.nix") ];
-            
+
+            # Ports are subject to change
+            # Disk size may be increased as needed
             virtualisation.forwardPorts = [
               { from = "host"; host.port = 2222; guest.port = 22; }
             ];
+            virtualisation.diskSize = 2048;
 
             users.users.root.hashedPassword = "";
 


### PR DESCRIPTION
- Closes #9 Adds all previous scripts from the DO box `/app/bin` to `common.nix` to be shared between `lasr_node` virtual machines. This all gets bundled into a new global script, `setup-working-dir.sh`, which handles initializing everything that is expected to be in the `/app` directory and is part of #10
- Closes #10 Starts `lasr_node` on server launch
- Closes #12 Pulls docker images declaratively, making them available to the guest machine on boot
- Closes #13 Uses the oci-runtime to run the pre-pulled docker images from #12 in an on server launch
- Closes #15 Adds documentation for using `nix-darwin` and general MacOS setup
- Closes #16 Adds a new global script `init-env.sh` for persisting environment variables between boots, this is also part of #10 
- Closes #19 Adds a local VM image for local development of `lasr_node` deployments for all supported systems.
- Closes #20 Adds a CI check for the new local VM images.