### PR TITLE
Create rust-toolchain overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,11 @@
         };
       };
 
+      overlays = {
+        fenix = inputs.fenix.overlays.default;
+        rust-toolchain = import ./overlays/rust-toolchain.nix;
+      };
+
       templates = {
         rust-package = {
           path = ./templates/rust-package;

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
       };
 
       overlays = {
-        fenix = inputs.fenix.overlays.default;
+        fenix = fenix.overlays.default;
         rust-toolchain = import ./overlays/rust-toolchain.nix;
       };
 

--- a/overlays/rust-toolchain.nix
+++ b/overlays/rust-toolchain.nix
@@ -1,0 +1,21 @@
+final: prev:
+let
+  mkRustToolchain = toml_path: hash: {
+    fenix-pkgs = (final.fenix.fromToolchainFile {
+      file = toml_path;
+      sha256 = hash;
+    });
+    darwin-pkgs = (with pkgs; lib.optionals stdenv.isDarwin [
+      # Additional darwin specific inputs
+      libiconv
+      darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
+    ]);
+    complete = [ fenix-pkgs darwin-pkgs ];
+  }
+in
+{
+  lib = prev.lib // {
+    inherit mkRustToolchain;
+  }; 
+}

--- a/overlays/rust-toolchain.nix
+++ b/overlays/rust-toolchain.nix
@@ -1,21 +1,25 @@
 final: prev:
 let
-  mkRustToolchain = toml_path: hash: {
-    fenix-pkgs = (final.fenix.fromToolchainFile {
-      file = toml_path;
-      sha256 = hash;
-    });
-    darwin-pkgs = (with pkgs; lib.optionals stdenv.isDarwin [
-      # Additional darwin specific inputs
-      libiconv
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.SystemConfiguration
-    ]);
-    complete = [ fenix-pkgs darwin-pkgs ];
-  };
+  mkRustToolchain = toml_path: hash:
+    let
+      fenix-pkgs = (final.fenix.fromToolchainFile {
+        file = toml_path;
+        sha256 = hash;
+      });
+      darwin-pkgs = (with final; lib.optionals stdenv.isDarwin [
+        # Additional darwin specific inputs
+        libiconv
+        darwin.apple_sdk.frameworks.Security
+        darwin.apple_sdk.frameworks.SystemConfiguration
+      ]);
+    in
+    {
+      inherit fenix-pkgs darwin-pkgs;
+      complete = [ fenix-pkgs darwin-pkgs ];
+    };
 in
 {
   lib = prev.lib // {
     inherit mkRustToolchain;
-  }; 
+  };
 }

--- a/overlays/rust-toolchain.nix
+++ b/overlays/rust-toolchain.nix
@@ -12,7 +12,7 @@ let
       darwin.apple_sdk.frameworks.SystemConfiguration
     ]);
     complete = [ fenix-pkgs darwin-pkgs ];
-  }
+  };
 in
 {
   lib = prev.lib // {


### PR DESCRIPTION
Closes #59 

Adds a rust-toolchain overlay for projects that will produce VMs and static binaries.